### PR TITLE
Use fully-qualified name in inventory plugin

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -113,7 +113,7 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-plugin: gcp_compute
+plugin: google.cloud.gcp_compute
 zones: # populate inventory with instances in these regions
   - us-east1-a
 projects:
@@ -281,7 +281,7 @@ class GcpInstance(object):
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
-    NAME = "gcp_compute"
+    NAME = "google.cloud.gcp_compute"
 
     _instances = (
         r"https://www.googleapis.com/compute/v1/projects/%s/aggregated/instances"


### PR DESCRIPTION
##### SUMMARY
Collections do not work without this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute inventory plugin

##### ADDITIONAL INFORMATION
If you use `google.cloud.gcp_compute` in your inventory file today you get:

> plugin: Incorrect plugin name in file: google.cloud.gcp_compute

If you leave it as-is, and use just `gcp_compute`, then it will use the inventory plugin in Ansible core, which will be removed soon.