### PR TITLE
adding tag to collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -36,7 +36,8 @@ license:
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
-#tags: []
+tags:
+    - cloud
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range


### PR DESCRIPTION
Adding cloud tag to collection so that when uploaded to AH and galaxy, when searched or selected (see AH quick nav buttons) it will show up.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
galaxy.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Adding this creates a better UX for net new users who are looking more generically for "cloud" based collections, rather than having them sift through and find it manually, we have setup buttons on the left for quick navigation for specific use cases, cloud being one. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
